### PR TITLE
Updated package paths to /vapor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "VaporPostgreSQL",
     dependencies: [
-   		 .Package(url: "https://github.com/qutheory/fluent-postgresql.git", majorVersion: 0, minor: 2),
-   		 .Package(url: "https://github.com/qutheory/vapor.git", majorVersion: 0, minor: 14)
+   		 .Package(url: "https://github.com/vapor/postgresql-driver.git", majorVersion: 0, minor: 2),
+   		 .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 0, minor: 13)
     ]
 )


### PR DESCRIPTION
Swift Package Manager had issues resolving dependencies that contained both /vapor and /qutheory 
