### PR TITLE
Update provider to support Vapor 1.1 specs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 let package = Package(
     name: "VaporPostgreSQL",
     dependencies: [
-   		 .Package(url: "https://github.com/vapor/postgresql-driver.git", majorVersion: 1),
-         .Package(url: "https://github.com/vapor/vapor.git", versions: Version(1,1,0)..<Version(2,0,0)),
+        .Package(url: "https://github.com/vapor/postgresql-driver.git", majorVersion: 1),
+        .Package(url: "https://github.com/vapor/vapor.git", versions: Version(1,1,0)..<Version(2,0,0)),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,6 @@ let package = Package(
     name: "VaporPostgreSQL",
     dependencies: [
    		 .Package(url: "https://github.com/vapor/postgresql-driver.git", majorVersion: 1),
-   		 .Package(url: "https://github.com/vapor/vapor.git", majorVersion: 1)
+         .Package(url: "https://github.com/vapor/vapor.git", versions: Version(1,1,0)..<Version(2,0,0)),
     ]
 )

--- a/Sources/VaporPostgreSQL/Provider.swift
+++ b/Sources/VaporPostgreSQL/Provider.swift
@@ -6,7 +6,6 @@ import FluentPostgreSQL
 public typealias PostgreSQLDriver = FluentPostgreSQL.PostgreSQLDriver
 
 public final class Provider: Vapor.Provider {
-    public let provided: Providable
 
     public enum Error: Swift.Error {
         case noPostgreSQLConfig
@@ -17,6 +16,13 @@ public final class Provider: Vapor.Provider {
         PostgreSQL database driver created by the provider.
     */
     public let driver: PostgreSQLDriver
+
+    public var provided: Providable {
+        print("[DEPRECATED] `provided` is deprecated and will not be available in future versions.")
+        return Providable(database: database)
+    }
+
+    private var database: Database
 
     /**
         Creates a PostgreSQL provider from a `postgresql.json` config file.
@@ -119,9 +125,14 @@ public final class Provider: Vapor.Provider {
         )
 
         self.driver = driver
+        self.database = Database(driver)
+    }
 
-        let database = Database(driver)
-        provided = Providable(database: database)
+    public func boot(_ drop: Droplet) {
+        if let existing = drop.database {
+            print("VaporPostgreSQL will overwrite existing database: \(type(of: existing))")
+        }
+        drop.database = database
     }
 
     /**

--- a/Tests/VaporPostgreSQLTests/PostgreSQLTests.swift
+++ b/Tests/VaporPostgreSQLTests/PostgreSQLTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Fluent
 import Node
 import Settings
+import Vapor
 @testable import VaporPostgreSQL
 
 
@@ -37,7 +38,7 @@ class VaporPostgreSQL: XCTestCase {
     }
 
     func testFileConfigWithoutPortOrHost() {
-        let fullConfig: Node = [
+        let partialConfig: Node = [
             "postgresql": [
                 "user": "postgres",
                 "password": "",
@@ -46,7 +47,7 @@ class VaporPostgreSQL: XCTestCase {
         ]
 
         do {
-            let config = Config(fullConfig)
+            let config = Config(partialConfig)
             let postgresql = try Provider.init(config: config)
             print("Database config parsed successfully")
             XCTAssertNotNil(postgresql.driver.database)
@@ -94,4 +95,16 @@ class VaporPostgreSQL: XCTestCase {
             XCTFail("Could not parse url: \(error)")
         }
     }
+
+    func testBoot() throws {
+        do {
+            let drop = Droplet()
+            let postgresql = try Provider.init(url: "psql://user:pass@host:5432/database")
+            postgresql.boot(drop)
+            XCTAssertNotNil(drop.database)
+        } catch {
+            XCTFail("Could prepare database: \(error)")
+        }
+    }
+
 }


### PR DESCRIPTION
Conform the PostgreSQL provider class to the updated Vapor Provider Protocol.

This fixes #7 
