### PR TITLE
fixing deprecated init to drop.addProvider()

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Adds PostgreSQL support to the Vapor web framework.
 import Vapor
 import VaporPostgreSQL
 
-let drop = Droplet(providers: [VaporPostgreSQL.Provider.self])
+let drop = Droplet()
+try drop.addProvider(VaporPostgreSQL.Provider.self)
 ```
 
 ## Config


### PR DESCRIPTION
the init that was shown is deprecated, i'm replacing to the new syntax provided in the documentation